### PR TITLE
Add convertPlaylistsToDataUrls

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "cookie": "^0.6.0",
     "crypto-js": "^4.2.0",
     "form-data": "^4.0.0",
+    "hls-parser": "^0.13.2",
     "iso-639-1": "^3.1.2",
     "nanoid": "^3.3.7",
     "node-fetch": "^3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   form-data:
     specifier: ^4.0.0
     version: 4.0.0
+  hls-parser:
+    specifier: ^0.13.2
+    version: 0.13.2
   iso-639-1:
     specifier: ^3.1.2
     version: 3.1.2
@@ -2530,6 +2533,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
     dev: true
+
+  /hls-parser@0.13.2:
+    resolution: {integrity: sha512-lKZitdq8Awcsb271BkbUCzXgBBZEhnMNcyAqre/cns2hItCV8nF3ucleT2QS37Ck+eUv7LwAD1t+F/1D/Vxkgg==}
+    dev: false
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}

--- a/src/providers/embeds/playm4u/nm.ts
+++ b/src/providers/embeds/playm4u/nm.ts
@@ -1,7 +1,9 @@
 import { load } from 'cheerio';
 import crypto from 'crypto-js';
 
+import { flags } from '@/entrypoint/utils/targets';
 import { makeEmbed } from '@/providers/base';
+import { convertPlaylistsToDataUrls } from '@/utils/playlist';
 
 const { AES, MD5 } = crypto;
 
@@ -113,9 +115,9 @@ export const playm4uNMScraper = makeEmbed({
         {
           id: 'primary',
           type: 'hls',
-          playlist: apiRes.data,
+          playlist: await convertPlaylistsToDataUrls(ctx.proxiedFetcher, apiRes.data),
           captions: [],
-          flags: [],
+          flags: [flags.CORS_ALLOWED],
         },
       ],
     };

--- a/src/providers/sources/m4ufree.ts
+++ b/src/providers/sources/m4ufree.ts
@@ -2,6 +2,7 @@
 // thanks Paradox_77
 import { load } from 'cheerio';
 
+import { flags } from '@/entrypoint/utils/targets';
 import { SourcererEmbed, makeSourcerer } from '@/providers/base';
 import { compareMedia } from '@/utils/compare';
 import { MovieScrapeContext, ShowScrapeContext } from '@/utils/context';
@@ -150,7 +151,7 @@ export const m4uScraper = makeSourcerer({
   id: 'm4ufree',
   name: 'M4UFree',
   rank: 125,
-  flags: [],
+  flags: [flags.CORS_ALLOWED],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,
 });

--- a/src/providers/sources/soapertv/index.ts
+++ b/src/providers/sources/soapertv/index.ts
@@ -4,6 +4,7 @@ import { flags } from '@/entrypoint/utils/targets';
 import { Caption, labelToLanguageCode } from '@/providers/captions';
 import { MovieScrapeContext, ShowScrapeContext } from '@/utils/context';
 import { NotFoundError } from '@/utils/errors';
+import { convertPlaylistsToDataUrls } from '@/utils/playlist';
 
 import { InfoResponse } from './types';
 import { SourcererOutput, makeSourcerer } from '../../base';
@@ -90,18 +91,18 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext): Pr
     stream: [
       {
         id: 'primary',
-        playlist: streamResJson.val,
+        playlist: await convertPlaylistsToDataUrls(ctx.proxiedFetcher, streamResJson.val),
         type: 'hls',
-        flags: [flags.IP_LOCKED],
+        flags: [flags.CORS_ALLOWED],
         captions,
       },
       ...(streamResJson.val_bak
         ? [
             {
               id: 'backup',
-              playlist: streamResJson.val_bak,
+              playlist: await convertPlaylistsToDataUrls(ctx.proxiedFetcher, streamResJson.val_bak),
               type: 'hls' as const,
-              flags: [flags.IP_LOCKED],
+              flags: [flags.CORS_ALLOWED],
               captions,
             },
           ]

--- a/src/utils/playlist.ts
+++ b/src/utils/playlist.ts
@@ -1,0 +1,23 @@
+import { parse, stringify } from 'hls-parser';
+import { MasterPlaylist } from 'hls-parser/types';
+
+import { UseableFetcher } from '@/fetchers/types';
+
+export async function convertPlaylistsToDataUrls(
+  fetcher: UseableFetcher,
+  playlistUrl: string,
+  headers?: Record<string, string>,
+) {
+  const playlistData = await fetcher(playlistUrl, { headers });
+  const playlist = parse(playlistData);
+
+  if (playlist.isMasterPlaylist) {
+    for (const variant of (playlist as MasterPlaylist).variants) {
+      const variantPlaylistData = await fetcher(variant.uri, { headers });
+      const variantPlaylist = parse(variantPlaylistData);
+      variant.uri = `data:application/vnd.apple.mpegurl;base64,${btoa(stringify(variantPlaylist))}`;
+    }
+  }
+
+  return `data:application/vnd.apple.mpegurl;base64,${btoa(stringify(playlist))}`;
+}


### PR DESCRIPTION
using convertPlaylistsToDataUrls makes soapertv and m4ufree (playm4u-nm) non-ext sources

 - [ ] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [ ] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [ ] I have tested all of my changes.
