### PR TITLE
Sudo Resurrection

### DIFF
--- a/src/providers/sources/catflix.ts
+++ b/src/providers/sources/catflix.ts
@@ -68,6 +68,7 @@ export const catflixScraper = makeSourcerer({
   id: 'catflix',
   name: 'Catflix',
   rank: 122,
+  disabled: true,
   flags: [],
   scrapeMovie: comboScraper,
   scrapeShow: comboScraper,

--- a/src/providers/sources/ee3/index.ts
+++ b/src/providers/sources/ee3/index.ts
@@ -91,7 +91,8 @@ async function comboScraper(ctx: MovieScrapeContext): Promise<SourcererOutput> {
 export const ee3Scraper = makeSourcerer({
   id: 'ee3',
   name: 'EE3',
-  rank: 111,
+  rank: 170,
+  disabled: false,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,
 });

--- a/src/providers/sources/hdrezka/index.ts
+++ b/src/providers/sources/hdrezka/index.ts
@@ -121,6 +121,7 @@ export const hdRezkaScraper = makeSourcerer({
   id: 'hdrezka',
   name: 'HDRezka',
   rank: 120,
+  disabled: true,
   flags: [flags.CORS_ALLOWED, flags.IP_LOCKED],
   scrapeShow: universalScraper,
   scrapeMovie: universalScraper,

--- a/src/providers/sources/m4ufree.ts
+++ b/src/providers/sources/m4ufree.ts
@@ -8,7 +8,7 @@ import { MovieScrapeContext, ShowScrapeContext } from '@/utils/context';
 import { makeCookieHeader, parseSetCookie } from '@/utils/cookie';
 import { NotFoundError } from '@/utils/errors';
 
-let baseUrl = 'https://m4ufree.tv';
+let baseUrl = 'https://m4uhd.tv';
 
 const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => {
   // this redirects to ww1.m4ufree.tv or ww2.m4ufree.tv
@@ -149,7 +149,8 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
 export const m4uScraper = makeSourcerer({
   id: 'm4ufree',
   name: 'M4UFree',
-  rank: 125,
+  rank: 130,
+  disabled: true,
   flags: [],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,

--- a/src/providers/sources/nites.ts
+++ b/src/providers/sources/nites.ts
@@ -73,6 +73,7 @@ export const nitesScraper = makeSourcerer({
   id: 'nites',
   name: 'Nites',
   rank: 90,
+  disabled: true,
   flags: [],
   scrapeMovie: comboScraper,
   scrapeShow: comboScraper,

--- a/src/providers/sources/nsbx.ts
+++ b/src/providers/sources/nsbx.ts
@@ -38,7 +38,7 @@ export const nsbxScraper = makeSourcerer({
   name: 'NSBX',
   rank: 129,
   flags: [flags.CORS_ALLOWED],
-  disabled: false,
+  disabled: true,
   scrapeMovie: comboScraper,
   scrapeShow: comboScraper,
 });

--- a/src/providers/sources/primewire/index.ts
+++ b/src/providers/sources/primewire/index.ts
@@ -81,6 +81,7 @@ export const primewireScraper = makeSourcerer({
   id: 'primewire',
   name: 'Primewire',
   rank: 1,
+  disabled: true,
   flags: [flags.CORS_ALLOWED],
   async scrapeMovie(ctx) {
     if (!ctx.media.imdbId) throw new Error('No imdbId provided');

--- a/src/providers/sources/ridomovies/index.ts
+++ b/src/providers/sources/ridomovies/index.ts
@@ -75,6 +75,7 @@ export const ridooMoviesScraper = makeSourcerer({
   id: 'ridomovies',
   name: 'RidoMovies',
   rank: 100,
+  disabled: true,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,

--- a/src/providers/sources/tugaflix/index.ts
+++ b/src/providers/sources/tugaflix/index.ts
@@ -11,6 +11,7 @@ export const tugaflixScraper = makeSourcerer({
   id: 'tugaflix',
   name: 'Tugaflix',
   rank: 73,
+  disabled: true,
   flags: [flags.IP_LOCKED],
   scrapeMovie: async (ctx) => {
     const searchResults = parseSearch(

--- a/src/providers/sources/warezcdn/index.ts
+++ b/src/providers/sources/warezcdn/index.ts
@@ -15,6 +15,7 @@ export const warezcdnScraper = makeSourcerer({
   id: 'warezcdn',
   name: 'WarezCDN',
   rank: 81,
+  disabled: true,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: async (ctx) => {
     if (!ctx.media.imdbId) throw new NotFoundError('This source requires IMDB id.');

--- a/src/providers/sources/whvx.ts
+++ b/src/providers/sources/whvx.ts
@@ -38,6 +38,7 @@ export const whvxScraper = makeSourcerer({
   id: 'whvx',
   name: 'VidBinge',
   rank: 128,
+  disabled: true,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,
   scrapeShow: comboScraper,


### PR DESCRIPTION
Remaining providers:

EEЗ
SoaperTV
FshareTV

---

- EE3 works again so I enabled it

- Disabled all broken providers

- Notes on some that might work if fixed:
Catflix returns 404
HDRezka returns incorrect video
M4UFree returns an encoded URL I think