### PR TITLE
Update rankings and disable broken providers

### DIFF
--- a/src/providers/embeds/autoembed.ts
+++ b/src/providers/embeds/autoembed.ts
@@ -31,7 +31,10 @@ const providers = [
 function embed(provider: { id: string; rank: number; disabled?: boolean }) {
   return makeEmbed({
     id: provider.id,
-    name: provider.id.split('-').map(word => word[0].toUpperCase() + word.slice(1)).join(' '),
+    name: provider.id
+      .split('-')
+      .map((word) => word[0].toUpperCase() + word.slice(1))
+      .join(' '),
     disabled: provider.disabled,
     rank: provider.rank,
     async scrape(ctx) {

--- a/src/providers/embeds/autoembed.ts
+++ b/src/providers/embeds/autoembed.ts
@@ -9,25 +9,30 @@ const providers = [
   {
     id: 'autoembed-hindi',
     rank: 9,
+    disabled: true,
   },
   {
     id: 'autoembed-tamil',
     rank: 8,
+    disabled: true,
   },
   {
     id: 'autoembed-telugu',
     rank: 7,
+    disabled: true,
   },
   {
     id: 'autoembed-bengali',
     rank: 6,
+    disabled: true,
   },
 ];
 
-function embed(provider: { id: string; rank: number }) {
+function embed(provider: { id: string; rank: number; disabled?: boolean }) {
   return makeEmbed({
     id: provider.id,
-    name: provider.id.charAt(0).toUpperCase() + provider.id.slice(1),
+    name: provider.id.split('-').map(word => word[0].toUpperCase() + word.slice(1)).join(' '),
+    disabled: provider.disabled,
     rank: provider.rank,
     async scrape(ctx) {
       return {

--- a/src/providers/sources/autoembed.ts
+++ b/src/providers/sources/autoembed.ts
@@ -42,7 +42,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const autoembedScraper = makeSourcerer({
   id: 'autoembed',
   name: 'Autoembed',
-  rank: 100,
+  rank: 90,
   disabled: false,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,

--- a/src/providers/sources/autoembed.ts
+++ b/src/providers/sources/autoembed.ts
@@ -38,7 +38,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const autoembedScraper = makeSourcerer({
   id: 'autoembed',
   name: 'Autoembed',
-  rank: 92,
+  rank: 100,
   disabled: false,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,

--- a/src/providers/sources/autoembed.ts
+++ b/src/providers/sources/autoembed.ts
@@ -27,7 +27,11 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
   for (const stream of fileData) {
     const url = stream.file;
     if (!url) continue;
-    embeds.push({ embedId: `autoembed-${stream.title.toLowerCase().trim()}`, url });
+    const lang = stream.title.toLowerCase().trim();
+    // only return english
+    if (lang.includes('english') && url) {
+      embeds.push({ embedId: `autoembed-${lang}`, url });
+    }
   }
 
   return {

--- a/src/providers/sources/autoembed.ts
+++ b/src/providers/sources/autoembed.ts
@@ -38,8 +38,8 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const autoembedScraper = makeSourcerer({
   id: 'autoembed',
   name: 'Autoembed',
-  rank: 10,
-  disabled: true,
+  rank: 92,
+  disabled: false,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,
   scrapeShow: comboScraper,

--- a/src/providers/sources/autoembed.ts
+++ b/src/providers/sources/autoembed.ts
@@ -27,11 +27,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
   for (const stream of fileData) {
     const url = stream.file;
     if (!url) continue;
-    const lang = stream.title.toLowerCase().trim();
-    // only return english
-    if (lang.includes('english') && url) {
-      embeds.push({ embedId: `autoembed-${lang}`, url });
-    }
+    embeds.push({ embedId: `autoembed-${stream.title.toLowerCase().trim()}`, url });
   }
 
   return {

--- a/src/providers/sources/bombtheirish.ts
+++ b/src/providers/sources/bombtheirish.ts
@@ -25,7 +25,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const bombtheirishScraper = makeSourcerer({
   id: 'bombtheirish',
   name: 'bombthe.irish',
-  rank: 50,
+  rank: 110,
   disabled: true,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,

--- a/src/providers/sources/bombtheirish.ts
+++ b/src/providers/sources/bombtheirish.ts
@@ -25,7 +25,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const bombtheirishScraper = makeSourcerer({
   id: 'bombtheirish',
   name: 'bombthe.irish',
-  rank: 110,
+  rank: 100,
   disabled: true,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,

--- a/src/providers/sources/bombtheirish.ts
+++ b/src/providers/sources/bombtheirish.ts
@@ -26,6 +26,7 @@ export const bombtheirishScraper = makeSourcerer({
   id: 'bombtheirish',
   name: 'bombthe.irish',
   rank: 50,
+  disabled: true,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,
   scrapeShow: comboScraper,

--- a/src/providers/sources/catflix.ts
+++ b/src/providers/sources/catflix.ts
@@ -5,11 +5,6 @@ import { MovieScrapeContext, ShowScrapeContext } from '@/utils/context';
 
 const baseUrl = 'https://catflix.su';
 
-function decodeBase64(encodedString: string): string {
-  const decodedString = atob(encodedString);
-  return decodedString;
-}
-
 async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promise<SourcererOutput> {
   const movieId = ctx.media.tmdbId;
   const mediaTitle = ctx.media.title.replace(/ /g, '-').replace(/[():]/g, '').toLowerCase();
@@ -58,7 +53,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 
   const Catflix1 = mainOriginMatch[1];
 
-  const decodedUrl = decodeBase64(Catflix1);
+  const decodedUrl = atob(Catflix1);
 
   ctx.progress(90);
 

--- a/src/providers/sources/catflix.ts
+++ b/src/providers/sources/catflix.ts
@@ -70,7 +70,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const catflixScraper = makeSourcerer({
   id: 'catflix',
   name: 'Catflix',
-  rank: 122,
+  rank: 170,
   flags: [],
   disabled: false,
   scrapeMovie: comboScraper,

--- a/src/providers/sources/ee3/index.ts
+++ b/src/providers/sources/ee3/index.ts
@@ -91,7 +91,7 @@ async function comboScraper(ctx: MovieScrapeContext): Promise<SourcererOutput> {
 export const ee3Scraper = makeSourcerer({
   id: 'ee3',
   name: 'EE3',
-  rank: 111,
+  rank: 80,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,
 });

--- a/src/providers/sources/ee3/index.ts
+++ b/src/providers/sources/ee3/index.ts
@@ -91,7 +91,7 @@ async function comboScraper(ctx: MovieScrapeContext): Promise<SourcererOutput> {
 export const ee3Scraper = makeSourcerer({
   id: 'ee3',
   name: 'EE3',
-  rank: 80,
+  rank: 150,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: comboScraper,
 });

--- a/src/providers/sources/flixhq/index.ts
+++ b/src/providers/sources/flixhq/index.ts
@@ -9,7 +9,7 @@ import { NotFoundError } from '@/utils/errors';
 export const flixhqScraper = makeSourcerer({
   id: 'flixhq',
   name: 'FlixHQ',
-  rank: 61,
+  rank: 230,
   flags: [flags.CORS_ALLOWED],
   disabled: true,
   async scrapeMovie(ctx) {

--- a/src/providers/sources/fsharetv.ts
+++ b/src/providers/sources/fsharetv.ts
@@ -88,7 +88,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const fsharetvScraper = makeSourcerer({
   id: 'fsharetv',
   name: 'FshareTV',
-  rank: 93,
+  rank: 220,
   flags: [],
   scrapeMovie: comboScraper,
 });

--- a/src/providers/sources/gomovies/index.ts
+++ b/src/providers/sources/gomovies/index.ts
@@ -17,7 +17,7 @@ export const gomoviesBase = `https://gomovies.sx`;
 export const goMoviesScraper = makeSourcerer({
   id: 'gomovies',
   name: 'GOmovies',
-  rank: 60,
+  rank: 50,
   disabled: true,
   flags: [flags.CORS_ALLOWED],
   async scrapeShow(ctx) {

--- a/src/providers/sources/goojara/index.ts
+++ b/src/providers/sources/goojara/index.ts
@@ -22,7 +22,7 @@ async function universalScraper(ctx: ShowScrapeContext | MovieScrapeContext): Pr
 export const goojaraScraper = makeSourcerer({
   id: 'goojara',
   name: 'Goojara',
-  rank: 70,
+  rank: 180,
   flags: [],
   disabled: true,
   scrapeShow: universalScraper,

--- a/src/providers/sources/hdrezka/index.ts
+++ b/src/providers/sources/hdrezka/index.ts
@@ -120,7 +120,7 @@ const universalScraper = async (ctx: ShowScrapeContext | MovieScrapeContext): Pr
 export const hdRezkaScraper = makeSourcerer({
   id: 'hdrezka',
   name: 'HDRezka',
-  rank: 120,
+  rank: 190,
   flags: [flags.CORS_ALLOWED, flags.IP_LOCKED],
   scrapeShow: universalScraper,
   scrapeMovie: universalScraper,

--- a/src/providers/sources/insertunit/index.ts
+++ b/src/providers/sources/insertunit/index.ts
@@ -12,6 +12,7 @@ export const insertunitScraper = makeSourcerer({
   id: 'insertunit',
   name: 'Insertunit',
   rank: 60,
+  disabled: true,
   flags: [flags.CORS_ALLOWED],
   async scrapeShow(ctx) {
     const playerData = await ctx.fetcher<string>(`/embed/imdb/${ctx.media.imdbId}`, {

--- a/src/providers/sources/insertunit/index.ts
+++ b/src/providers/sources/insertunit/index.ts
@@ -11,7 +11,7 @@ const insertUnitBase = 'https://api.insertunit.ws/';
 export const insertunitScraper = makeSourcerer({
   id: 'insertunit',
   name: 'Insertunit',
-  rank: 120,
+  rank: 110,
   disabled: true,
   flags: [flags.CORS_ALLOWED],
   async scrapeShow(ctx) {

--- a/src/providers/sources/insertunit/index.ts
+++ b/src/providers/sources/insertunit/index.ts
@@ -11,7 +11,7 @@ const insertUnitBase = 'https://api.insertunit.ws/';
 export const insertunitScraper = makeSourcerer({
   id: 'insertunit',
   name: 'Insertunit',
-  rank: 60,
+  rank: 120,
   disabled: true,
   flags: [flags.CORS_ALLOWED],
   async scrapeShow(ctx) {

--- a/src/providers/sources/lookmovie/index.ts
+++ b/src/providers/sources/lookmovie/index.ts
@@ -33,7 +33,7 @@ export const lookmovieScraper = makeSourcerer({
   id: 'lookmovie',
   name: 'LookMovie',
   disabled: true,
-  rank: 50,
+  rank: 60,
   flags: [flags.IP_LOCKED],
   scrapeShow: universalScraper,
   scrapeMovie: universalScraper,

--- a/src/providers/sources/m4ufree.ts
+++ b/src/providers/sources/m4ufree.ts
@@ -154,7 +154,7 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
 export const m4uScraper = makeSourcerer({
   id: 'm4ufree',
   name: 'M4UFree',
-  rank: 60,
+  rank: 200,
   disabled: true,
   flags: [],
   scrapeMovie: universalScraper,

--- a/src/providers/sources/m4ufree.ts
+++ b/src/providers/sources/m4ufree.ts
@@ -114,15 +114,11 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
   for (const source of sources) {
     let embedId;
 
-    if (source.name === 'm') {
-      embedId = 'playm4u-m';
-    } else if (source.name === 'nm') {
-      continue;
-    } else if (source.name === 'h') {
-      embedId = 'playm4u-nm';
-    } else {
-      continue;
-    }
+    if (source.name === 'm')
+      embedId = 'playm4u-m'; // TODO
+    else if (source.name === 'nm') embedId = 'playm4u-nm';
+    else if (source.name === 'h') embedId = 'hydrax';
+    else continue;
 
     const iframePage$ = load(
       await ctx.proxiedFetcher<string>('/ajax', {
@@ -155,7 +151,7 @@ export const m4uScraper = makeSourcerer({
   id: 'm4ufree',
   name: 'M4UFree',
   rank: 200,
-  disabled: true,
+  disabled: false,
   flags: [],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,

--- a/src/providers/sources/m4ufree.ts
+++ b/src/providers/sources/m4ufree.ts
@@ -151,7 +151,7 @@ export const m4uScraper = makeSourcerer({
   id: 'm4ufree',
   name: 'M4UFree',
   rank: 200,
-  disabled: false,
+  disabled: true,
   flags: [],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,

--- a/src/providers/sources/m4ufree.ts
+++ b/src/providers/sources/m4ufree.ts
@@ -113,11 +113,16 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
 
   for (const source of sources) {
     let embedId;
-    if (source.name === 'm')
-      embedId = 'playm4u-m'; // TODO
-    else if (source.name === 'nm') embedId = 'playm4u-nm';
-    else if (source.name === 'h') embedId = 'hydrax';
-    else continue;
+
+    if (source.name === 'm') {
+      embedId = 'playm4u-m';
+    } else if (source.name === 'nm') {
+      continue;
+    } else if (source.name === 'h') {
+      embedId = 'playm4u-nm';
+    } else {
+      continue;
+    }
 
     const iframePage$ = load(
       await ctx.proxiedFetcher<string>('/ajax', {
@@ -149,7 +154,8 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
 export const m4uScraper = makeSourcerer({
   id: 'm4ufree',
   name: 'M4UFree',
-  rank: 125,
+  rank: 60,
+  disabled: true,
   flags: [],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,

--- a/src/providers/sources/nepu/index.ts
+++ b/src/providers/sources/nepu/index.ts
@@ -76,7 +76,7 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
 export const nepuScraper = makeSourcerer({
   id: 'nepu',
   name: 'Nepu',
-  rank: 80,
+  rank: 210,
   disabled: true,
   flags: [],
   scrapeMovie: universalScraper,

--- a/src/providers/sources/nites.ts
+++ b/src/providers/sources/nites.ts
@@ -73,7 +73,7 @@ export const nitesScraper = makeSourcerer({
   id: 'nites',
   name: 'Nites',
   disabled: true,
-  rank: 90,
+  rank: 80,
   flags: [],
   scrapeMovie: comboScraper,
   scrapeShow: comboScraper,

--- a/src/providers/sources/nsbx.ts
+++ b/src/providers/sources/nsbx.ts
@@ -36,7 +36,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const nsbxScraper = makeSourcerer({
   id: 'nsbx',
   name: 'NSBX',
-  rank: 129,
+  rank: 290,
   flags: [flags.CORS_ALLOWED],
   disabled: true,
   externalSource: true,

--- a/src/providers/sources/primewire/index.ts
+++ b/src/providers/sources/primewire/index.ts
@@ -80,7 +80,7 @@ async function getStreams(title: string) {
 export const primewireScraper = makeSourcerer({
   id: 'primewire',
   name: 'Primewire',
-  rank: 1,
+  rank: 10,
   disabled: true,
   flags: [flags.CORS_ALLOWED],
   async scrapeMovie(ctx) {

--- a/src/providers/sources/redstar.ts
+++ b/src/providers/sources/redstar.ts
@@ -37,7 +37,7 @@ export const redStarScraper = makeSourcerer({
   name: 'redStar',
   disabled: true,
   externalSource: true,
-  rank: 131,
+  rank: 280,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,

--- a/src/providers/sources/remotestream.ts
+++ b/src/providers/sources/remotestream.ts
@@ -11,7 +11,7 @@ export const remotestreamScraper = makeSourcerer({
   id: 'remotestream',
   name: 'Remote Stream',
   disabled: true,
-  rank: 20,
+  rank: 30,
   flags: [flags.CORS_ALLOWED],
   async scrapeShow(ctx) {
     const seasonNumber = ctx.media.season.number;

--- a/src/providers/sources/ridomovies/index.ts
+++ b/src/providers/sources/ridomovies/index.ts
@@ -73,7 +73,7 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
 export const ridooMoviesScraper = makeSourcerer({
   id: 'ridomovies',
   name: 'RidoMovies',
-  rank: 100,
+  rank: 130,
   flags: [],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,

--- a/src/providers/sources/ridomovies/index.ts
+++ b/src/providers/sources/ridomovies/index.ts
@@ -1,6 +1,5 @@
 import { load } from 'cheerio';
 
-import { flags } from '@/entrypoint/utils/targets';
 import { SourcererEmbed, makeSourcerer } from '@/providers/base';
 import { closeLoadScraper } from '@/providers/embeds/closeload';
 import { ridooScraper } from '@/providers/embeds/ridoo';
@@ -75,7 +74,7 @@ export const ridooMoviesScraper = makeSourcerer({
   id: 'ridomovies',
   name: 'RidoMovies',
   rank: 100,
-  flags: [flags.CORS_ALLOWED],
+  flags: [],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,
 });

--- a/src/providers/sources/ridomovies/index.ts
+++ b/src/providers/sources/ridomovies/index.ts
@@ -73,7 +73,7 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
 export const ridooMoviesScraper = makeSourcerer({
   id: 'ridomovies',
   name: 'RidoMovies',
-  rank: 130,
+  rank: 120,
   flags: [],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,

--- a/src/providers/sources/showbox/index.ts
+++ b/src/providers/sources/showbox/index.ts
@@ -41,7 +41,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const showboxScraper = makeSourcerer({
   id: 'showbox',
   name: 'Showbox',
-  rank: 150,
+  rank: 250,
   disabled: true,
   flags: [flags.CORS_ALLOWED, flags.CF_BLOCKED],
   scrapeShow: comboScraper,

--- a/src/providers/sources/smashystream/index.ts
+++ b/src/providers/sources/smashystream/index.ts
@@ -30,7 +30,7 @@ const universalScraper = async (ctx: ShowScrapeContext | MovieScrapeContext): Pr
 export const smashyStreamScraper = makeSourcerer({
   id: 'smashystream',
   name: 'SmashyStream',
-  rank: 30,
+  rank: 20,
   disabled: true,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: universalScraper,

--- a/src/providers/sources/soapertv/index.ts
+++ b/src/providers/sources/soapertv/index.ts
@@ -115,7 +115,7 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext): Pr
 export const soaperTvScraper = makeSourcerer({
   id: 'soapertv',
   name: 'SoaperTV',
-  rank: 126,
+  rank: 160,
   flags: [flags.CORS_ALLOWED],
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,

--- a/src/providers/sources/tugaflix/index.ts
+++ b/src/providers/sources/tugaflix/index.ts
@@ -10,7 +10,7 @@ import { baseUrl, parseSearch } from './common';
 export const tugaflixScraper = makeSourcerer({
   id: 'tugaflix',
   name: 'Tugaflix',
-  rank: 73,
+  rank: 90,
   flags: [flags.IP_LOCKED],
   scrapeMovie: async (ctx) => {
     const searchResults = parseSearch(

--- a/src/providers/sources/tugaflix/index.ts
+++ b/src/providers/sources/tugaflix/index.ts
@@ -10,7 +10,7 @@ import { baseUrl, parseSearch } from './common';
 export const tugaflixScraper = makeSourcerer({
   id: 'tugaflix',
   name: 'Tugaflix',
-  rank: 90,
+  rank: 70,
   flags: [flags.IP_LOCKED],
   scrapeMovie: async (ctx) => {
     const searchResults = parseSearch(

--- a/src/providers/sources/vidsrc/index.ts
+++ b/src/providers/sources/vidsrc/index.ts
@@ -5,7 +5,7 @@ import { scrapeShow } from '@/providers/sources/vidsrc/scrape-show';
 export const vidsrcScraper = makeSourcerer({
   id: 'vidsrc',
   name: 'VidSrc',
-  rank: 90,
+  rank: 130,
   disabled: true,
   flags: [],
   scrapeMovie,

--- a/src/providers/sources/vidsrcto/index.ts
+++ b/src/providers/sources/vidsrcto/index.ts
@@ -86,5 +86,5 @@ export const vidSrcToScraper = makeSourcerer({
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,
   flags: [flags.PROXY_BLOCKED],
-  rank: 130,
+  rank: 260,
 });

--- a/src/providers/sources/warezcdn/index.ts
+++ b/src/providers/sources/warezcdn/index.ts
@@ -1,4 +1,3 @@
-import { flags } from '@/entrypoint/utils/targets';
 import { SourcererEmbed, SourcererOutput, makeSourcerer } from '@/providers/base';
 import { mixdropScraper } from '@/providers/embeds/mixdrop';
 import { warezcdnembedHlsScraper } from '@/providers/embeds/warezcdn/hls';

--- a/src/providers/sources/warezcdn/index.ts
+++ b/src/providers/sources/warezcdn/index.ts
@@ -47,7 +47,7 @@ async function getEmbeds(id: string, servers: string, ctx: ScrapeContext): Promi
 export const warezcdnScraper = makeSourcerer({
   id: 'warezcdn',
   name: 'WarezCDN',
-  rank: 101,
+  rank: 140,
   flags: [],
   scrapeMovie: async (ctx) => {
     if (!ctx.media.imdbId) throw new NotFoundError('This source requires IMDB id.');

--- a/src/providers/sources/warezcdn/index.ts
+++ b/src/providers/sources/warezcdn/index.ts
@@ -48,8 +48,8 @@ async function getEmbeds(id: string, servers: string, ctx: ScrapeContext): Promi
 export const warezcdnScraper = makeSourcerer({
   id: 'warezcdn',
   name: 'WarezCDN',
-  rank: 81,
-  flags: [flags.CORS_ALLOWED],
+  rank: 101,
+  flags: [],
   scrapeMovie: async (ctx) => {
     if (!ctx.media.imdbId) throw new NotFoundError('This source requires IMDB id.');
     const serversPage = await ctx.proxiedFetcher<string>(`/filme/${ctx.media.imdbId}`, {

--- a/src/providers/sources/whvx.ts
+++ b/src/providers/sources/whvx.ts
@@ -37,7 +37,7 @@ async function comboScraper(ctx: ShowScrapeContext | MovieScrapeContext): Promis
 export const whvxScraper = makeSourcerer({
   id: 'whvx',
   name: 'VidBinge',
-  rank: 128,
+  rank: 270,
   disabled: true,
   externalSource: true,
   flags: [flags.CORS_ALLOWED],

--- a/src/providers/sources/zoechip/index.ts
+++ b/src/providers/sources/zoechip/index.ts
@@ -6,7 +6,7 @@ import { scrapeShow } from '@/providers/sources/zoechip/scrape-show';
 export const zoechipScraper = makeSourcerer({
   id: 'zoechip',
   name: 'ZoeChip',
-  rank: 62,
+  rank: 240,
   flags: [flags.CORS_ALLOWED],
   disabled: true,
   scrapeMovie,


### PR DESCRIPTION
Changes:
- Fixed Catflix
- Enabled Autoembed
- Disabled Bombthe.irish
- Disabled Insertunit
- Disabled M4uFree
- Updated source order
- Updated extension required providers

```
Working sources:
- SoaperTV
- EE3
- Autoembed
Extension required:
- Catflix
- HDRezka
- WarezCDN
- RidoMovies
- FshareTV
- Tugaflix
```